### PR TITLE
Use Unikraft-provided __offsetof instead of own

### DIFF
--- a/_elftc.h
+++ b/_elftc.h
@@ -38,7 +38,16 @@
 #endif
 
 #ifndef	offsetof
+#if defined(__Unikraft__)
+#include <uk/essentials.h>
+
+#define	offsetof(T, M)		__offsetof(T, M)
+
+#else /* !__Unikraft */
+
 #define	offsetof(T, M)		((int) &((T*) 0) -> M)
+
+#endif /* !__Unikraft */
 #endif
 
 /* --QUEUE-MACROS-- [[ */


### PR DESCRIPTION
This change has _elftc.h define the libelf offsetof macro using the Unikraft __offsetof, instead of defining its own. The latter uses a wrong integer size for casting a pointer on 64-bit architectures.